### PR TITLE
Bring jsdelivr back into the fold

### DIFF
--- a/config/config.template.js
+++ b/config/config.template.js
@@ -6,7 +6,7 @@ module.exports = {
         bootstrap: {minute: 0},
         cdnjs: {minute: 2},
         google: {minute: 4},
-        //jsdelivr: {minute: 7},
+        jsdelivr: {minute: 7}
         //jquery: {minute: 5}
     }
 };

--- a/tasks/index.js
+++ b/tasks/index.js
@@ -2,7 +2,7 @@
 
 module.exports = function(output, github) {
     //var cdns = ['bootstrap', 'cdnjs', 'google', 'jquery', 'jsdelivr'];
-    var cdns = ['bootstrap', 'cdnjs', 'google'];
+    var cdns = ['bootstrap', 'cdnjs', 'google', 'jsdelivr'];
     var ret = {};
 
     cdns.forEach(function(cdn) {


### PR DESCRIPTION
Leaving out jQuery API for now.
