### PR TITLE
fix "name": "twitter-bootstrap" (v1 & v2)

### DIFF
--- a/tasks/bootstrap.js
+++ b/tasks/bootstrap.js
@@ -32,11 +32,8 @@ module.exports = function(github) {
             objBootstrap = JSON.parse(JSON.stringify(objParsed[matchIndex])); // copys sub-array
             objBootstrap.name = "bootstrap";
 
-            // merge fix, leaving "twitter-bootstrap" in for compatabilty
-            objFixed = JSON.stringify(objParsed).substr(1); // original array without the first character, which should be `[`
-            objFixed = "[" + JSON.stringify(objBootstrap) + "," + objFixed; // prepend correction
-            objFixed = JSON.parse(objFixed); // make into Object again
-
+            // merge & send fix, leaving "twitter-bootstrap" in for compatabilty
+            objFixed = [objBootstrap, objParsed];
             cb(null, objFixed);
             //=end v1 bugfix https://github.com/jsdelivr/api/issues/50
 


### PR DESCRIPTION
fix for https://github.com/jsdelivr/api/issues/50 where expected API call is http://api.jsdelivr.com/v1/bootstrap/libraries?name=bootstrap but http://api.jsdelivr.com/v1/bootstrap/libraries?name=twitter-bootstrap is actual.
v1: keeps both for compatibility.  It clones, fixes, then prepends. (live)
v2 (of both api & api-sync): only renames (commented out)
todo: warn not to use "twitter-bootstrap"
