### PR TITLE
Use conditional requests for jsdelivr json file updates.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,5 @@
 data/
 node_modules/
 *.swp
+
+.idea

--- a/tasks/index.js
+++ b/tasks/index.js
@@ -3,6 +3,7 @@
 module.exports = function(output, github) {
     //var cdns = ['bootstrap', 'cdnjs', 'google', 'jquery', 'jsdelivr'];
     var cdns = ['bootstrap', 'cdnjs', 'google', 'jsdelivr'];
+    //var cdns = ['jsdelivr'];
     var ret = {};
 
     cdns.forEach(function(cdn) {

--- a/tasks/jsdelivr.js
+++ b/tasks/jsdelivr.js
@@ -1,187 +1,220 @@
 'use strict';
 
-var url = require('url');
-
-var async = require('async');
-var extend = require('extend');
-var fp = require('annofp');
-var prop = fp.prop;
-var values = fp.values;
-
-var request = require('request');
-var ini = require('ini');
+var url = require('url')
+  , async = require('async')
+  , extend = require('extend')
+  , fp = require('annofp')
+  , prop = fp.prop
+  , values = fp.values
+  , request = require('request')
+  , ini = require('ini')
+  , fs = require('fs')
+  , path = require('path');
 
 var utils = require('../lib/utils');
-var contains = utils.contains;
 
+var contains = utils.contains;
 
 module.exports = function(github) {
 
-    return function(cb) {
-        getFiles(function(err, files) {
+  var etagsFilePath = path.resolve(__dirname,'../data/jsdelivr_etags.json');
+
+  return function(cb) {
+
+    getFiles(function(err,files,etags) {
+
+      //write etags value to file
+      fs.writeFile(etagsFilePath, JSON.stringify(etags), function(err) {
+        if(err) {
+          console.log(err);
+        } else {
+          console.log("etags saved to " + etagsFilePath);
+        }
+      });
+
+      parse(files, cb);
+    });
+  };
+
+  function parse(files, cb) {
+    var base = 'https://raw.githubusercontent.com/jsdelivr/jsdelivr/master/files/';
+    var ret = {};
+
+    async.eachLimit(files, 4, function(file, cb) {
+      var parts = file.split('/');
+      var name = parts[0];
+      var filename, version;
+
+      if(parts.length === 2) {
+        if(parts[1] === 'info.ini') {
+          return parseIni(url.resolve(base, file), function(err, d) {
             if(err) {
-                return cb(err);
-            }
-
-            parse(files, cb);
-        });
-    };
-
-    function parse(files, cb) {
-        var base = 'https://raw.githubusercontent.com/jsdelivr/jsdelivr/master/files/';
-        var ret = {};
-
-        async.eachLimit(files, 4, function(file, cb) {
-            var parts = file.split('/');
-            var name = parts[0];
-            var filename, version;
-
-            if(parts.length === 2) {
-                if(parts[1] === 'info.ini') {
-                    return parseIni(url.resolve(base, file), function(err, d) {
-                        if(err) {
-                            return setImmediate(cb.bind(null, err));
-                        }
-
-                        if(!(name in ret)) {
-                            ret[name] = {
-                                name: name,
-                                versions: [],
-                                assets: {}, // version -> assets
-                                zip: name + '.zip'
-                            };
-                        }
-
-                        ret[name] = extend(ret[name], d);
-
-                        setImmediate(cb);
-                    });
-                }
-
-                return setImmediate(cb);
-            }
-            else {
-                version = parts[1];
-                filename = parts.slice(2).join('/');
+              return setImmediate(cb.bind(null, err));
             }
 
             if(!(name in ret)) {
-                ret[name] = {
-                    name: name,
-                    versions: [],
-                    assets: {} // version -> assets
-                };
+              ret[name] = {
+                name: name,
+                versions: [],
+                assets: {}, // version -> assets
+                zip: name + '.zip'
+              };
             }
 
-            var lib = ret[name];
-
-            // version
-            if(lib.versions.indexOf(version) === -1) {
-                lib.versions.push(version);
-            }
-
-            // assets
-            if(!(version in lib.assets)) {
-                lib.assets[version] = [];
-            }
-
-            lib.assets[version].push(filename);
+            ret[name] = extend(ret[name], d);
 
             setImmediate(cb);
-        }, function(err) {
-            if(err) {
-                return cb(err);
-            }
+          });
+        }
 
-            cb(null, values(ret).map(function(v) {
-                // convert assets to v1 format
-                var assets = [];
+        return setImmediate(cb);
+      }
+      else {
+        version = parts[1];
+        filename = parts.slice(2).join('/');
+      }
 
-                fp.each(function(version, files) {
-                    assets.push({
-                        version: version,
-                        files: files
-                    });
-                }, v.assets);
+      if(!(name in ret)) {
+        ret[name] = {
+          name: name,
+          versions: [],
+          assets: {} // version -> assets
+        };
+      }
 
-                v.assets = assets;
+      var lib = ret[name];
 
-                return v;
-            }));
-        });
+      // version
+      if(lib.versions.indexOf(version) === -1) {
+        lib.versions.push(version);
+      }
+
+      // assets
+      if(!(version in lib.assets)) {
+        lib.assets[version] = [];
+      }
+
+      lib.assets[version].push(filename);
+
+      setImmediate(cb);
+    }, function(err) {
+      if(err) {
+        return cb(err);
+      }
+
+      //console.log(JSON.stringify(ret));
+      cb(null, values(ret).map(function(v) {
+        // convert assets to v1 format
+        var assets = [];
+
+        fp.each(function(version, files) {
+          assets.push({
+            version: version,
+            files: files
+          });
+        }, v.assets);
+
+        v.assets = assets;
+
+        return v;
+      }));
+    });
+  }
+
+  function parseIni(url, cb) {
+    request.get(url, function(err, res, data) {
+      if(err) {
+        return cb(err);
+      }
+
+      cb(null, ini.parse(data));
+    });
+  }
+
+  function getFiles(cb) {
+
+    //attempt to get etags file
+    var etags;
+    try {
+      etags = require(etagsFilePath);
+    } catch(err) {
+      console.log('There is no cached etags file, starting from scratch');
+      etags = {};
     }
 
-    function parseIni(url, cb) {
-        request.get(url, function(err, res, data) {
-            if(err) {
-                return cb(err);
-            }
+    github.repos.getContent({
+      user: 'jsdelivr',
+      repo: 'jsdelivr',
+      path: ''
+    }, function(err, res) {
+      if(err) {
+        return cb(err);
+      }
 
-            cb(null, ini.parse(data));
+      var sha = res.filter(function(v) {
+        return v.name === 'files';
+      })[0].sha;
+
+      github.gitdata.getTree({
+        user: 'jsdelivr',
+        repo: 'jsdelivr',
+        sha: sha
+      }, function(err, res) {
+        if(err) {
+          return cb(err);
+        }
+
+        if(!res.tree) {
+          return cb(new Error('Missing tree'));
+        }
+
+        // get each dir under /files
+        var dirs = res.tree.filter(function(v) {
+          return v.mode.indexOf('040') === 0;
         });
-    }
 
-    function getFiles(cb) {
-        github.repos.getContent({
+        var files = [];
+
+        async.eachLimit(dirs, 8, function(dir, done) {
+
+          var config = {
             user: 'jsdelivr',
             repo: 'jsdelivr',
-            path: ''
-        }, function(err, res) {
-            if(err) {
-                return cb(err);
+            sha: dir.sha,
+            recursive: 1 // just recurse these smaller directories
+          };
+          if(etags[dir.sha]) // add conditional request
+            config.headers = {
+            "If-None-Match": etags[dir.sha]
+          };
+          github.gitdata.getTree(config, function(err, res) {
+            //console.log(JSON.stringify(res))
+            // skip invalid entries, don't abort the entire update
+            //console.log(JSON.stringify(res.meta))
+            if (!err && res.tree) {
+              //console.log(JSON.stringify(res.meta));
+
+              //set sha => etag map so we know the response state
+              etags[dir.sha] = res.meta["etag"];
+              res.tree.forEach(function(file) {
+                // prepend the original base dir
+                file.path = dir.path + '/' + file.path;
+                files.push(file);
+              });
             }
 
-            var sha = res.filter(function(v) {
-                return v.name === 'files';
-            })[0].sha;
+            setImmediate(done);
+          });
+        }, function(err) {
+          var filtered = files.filter(function(v) {
+            return v.mode.indexOf('100') === 0;
+          }).map(prop('path')).filter(contains('/'));
 
-            github.gitdata.getTree({
-                user: 'jsdelivr',
-                repo: 'jsdelivr',
-                sha: sha
-            }, function(err, res) {
-                if(err) {
-                    return cb(err);
-                }
-
-                if(!res.tree) {
-                    return cb(new Error('Missing tree'));
-                }
-
-                // get each dir under /files
-                var dirs = res.tree.filter(function(v) {
-                    return v.mode.indexOf('040') === 0;
-                });
-
-                var files = [];
-
-                async.eachLimit(dirs, 8, function(dir, done) {
-                    github.gitdata.getTree({
-                        user: 'jsdelivr',
-                        repo: 'jsdelivr',
-                        sha: dir.sha,
-                        recursive: 1 // just recurse these smaller directories
-                    }, function(err, res) {
-
-                        // skip invalid entries, don't abort the entire update
-                        if (!err && res.tree) {
-                            res.tree.forEach(function(file) {
-                                // prepend the original base dir
-                                file.path = dir.path + '/' + file.path;
-                                files.push(file);
-                            });
-                        }
-
-                        setImmediate(done);
-                    });
-                }, function(err) {
-                    var filtered = files.filter(function(v) {
-                        return v.mode.indexOf('100') === 0;
-                    }).map(prop('path')).filter(contains('/'));
-
-                    cb(null, filtered);
-                });
-            });
+           cb(null, filtered, etags);
         });
-    }
+
+
+      });
+    });
+  }
 };

--- a/tasks/task.js
+++ b/tasks/task.js
@@ -7,52 +7,92 @@ var sortVersions = require('../lib/sort_versions');
 
 
 module.exports = function(output, target, scrape) {
-    return function(cb) {
-        console.log('Starting to update ' + target + ' data');
+  return function(cb) {
+    console.log('Starting to update ' + target + ' data');
 
-        scrape(function(err, libraries) {
-            if(err) {
-                console.error('Failed to update ' + target + ' data!', err);
+    scrape(function(err, libraries) {
+      if(err) {
+        console.error('Failed to update ' + target + ' data!', err);
 
-                return cb(err);
-            }
+        return cb(err);
+      }
 
-            var p = path.join(output, target + '.json');
+      var p = path.resolve(__dirname,'../',output, target + '.json');
 
-            libraries = libraries.map(function(library) {
-                library.versions = sortVersions(library.versions);
+      libraries = libraries.map(function(library) {
+        library.versions = sortVersions(library.versions);
 
-                // skip if library is missing versions for some reason
-                if(!library.versions) {
-                    console.warn('Failed to find versions for', library);
+        // skip if library is missing versions for some reason
+        if(!library.versions) {
+          console.warn('Failed to find versions for', library);
 
-                    return;
-                }
+          return;
+        }
 
-                library.lastversion = library.versions[0];
+        library.lastversion = library.versions[0];
 
-                return library;
-            }).filter(id);
+        return library;
+      }).filter(id);
 
-            fs.writeFile(
-                p,
-                JSON.stringify(libraries),
-                function(err) {
-                    if(err) {
-                        console.error('Failed to write', p);
+      var updatedTarget = merge(p,libraries);
+      fs.writeFile(
+        p,
+        JSON.stringify(updatedTarget),
+        function(err) {
+          if(err) {
+            console.error('Failed to write', p);
 
-                        return cb(err);
-                    }
+            return cb(err);
+          }
 
-                    console.log('Updated', target, 'data');
+          console.log('Updated', target, 'data');
 
-                    cb();
-                }
-            );
-        });
-    };
+          cb();
+        }
+      );
+    });
+  };
 };
 
 function id(a) {
-    return a;
+  return a;
+}
+
+function merge(target,libraries) {
+
+  var _listToMap = function(list) {
+    var map = {};
+    for(var i = 0; i < list.length; i++) {
+      map[list[i].name] = list[i];
+    }
+    return map;
+  };
+
+  var _mapToList = function(map) {
+    var list = [];
+    for(var key in map) {
+      list.push(map[key]);
+    }
+    return list;
+  };
+
+  var targetJSON
+    , updatedJSON;
+  try {
+    targetJSON = require(target);
+  } catch (err) {
+    console.log(target + " does not yet exist, initializing w/ retrieved data");
+    targetJSON = [];
+  }
+
+  var targetDBMap = _listToMap(targetJSON)
+    , freshDBMap = _listToMap(libraries);
+
+  for(var key in freshDBMap) {
+    targetDBMap[key] = freshDBMap[key];
+  }
+
+  updatedJSON = _mapToList(targetDBMap);
+
+  return updatedJSON;
 }


### PR DESCRIPTION
[Conditional Requests](https://developer.github.com/v3/#conditional-requests) are used to limit the Github API usage for `jsdelivr.json` updates. This reduces the API usage when checking for updated jsdelivr data from several hundred calls, to two. We also now use the 'merge' approach for all json file updates (rather than 'replace' approach) to accommodate back filling data as updates are received.