### PR TITLE
remove nodemailer-smtp-transport module

### DIFF
--- a/lib/mail.js
+++ b/lib/mail.js
@@ -3,7 +3,6 @@
  */
 
 var nodemailer = require('nodemailer')
-  , smtpTransport = require('nodemailer-smtp-transport')
   , log = require('./log')
 
   , config = require('../config');
@@ -11,7 +10,7 @@ var nodemailer = require('nodemailer')
 var smtpOptions = config.smtp;
 smtpOptions.auth = config.smtpAuth;
 
-var transporter = nodemailer.createTransport(smtpTransport(smtpOptions));
+var transporter = nodemailer.createTransport(smtpOptions);
 
 function _send(subject,msg,cb) {
 

--- a/npm-shrinkwrap.json
+++ b/npm-shrinkwrap.json
@@ -598,7 +598,7 @@
     },
     "nodemailer": {
       "version": "1.3.0",
-      "from": "nodemailer@",
+      "from": "https://registry.npmjs.org/nodemailer/-/nodemailer-1.3.0.tgz",
       "resolved": "https://registry.npmjs.org/nodemailer/-/nodemailer-1.3.0.tgz",
       "dependencies": {
         "buildmail": {
@@ -646,9 +646,9 @@
           "resolved": "https://registry.npmjs.org/libmime/-/libmime-0.1.7.tgz",
           "dependencies": {
             "iconv-lite": {
-              "version": "0.4.6",
+              "version": "0.4.7",
               "from": "iconv-lite@^0.4.4",
-              "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.4.6.tgz"
+              "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.4.7.tgz"
             },
             "libbase64": {
               "version": "0.1.0",
@@ -680,9 +680,9 @@
           "resolved": "https://registry.npmjs.org/nodemailer-smtp-transport/-/nodemailer-smtp-transport-0.1.13.tgz",
           "dependencies": {
             "nodemailer-wellknown": {
-              "version": "0.1.4",
+              "version": "0.1.5",
               "from": "nodemailer-wellknown@^0.1.1",
-              "resolved": "https://registry.npmjs.org/nodemailer-wellknown/-/nodemailer-wellknown-0.1.4.tgz"
+              "resolved": "https://registry.npmjs.org/nodemailer-wellknown/-/nodemailer-wellknown-0.1.5.tgz"
             },
             "smtp-connection": {
               "version": "1.1.0",
@@ -690,23 +690,6 @@
               "resolved": "https://registry.npmjs.org/smtp-connection/-/smtp-connection-1.1.0.tgz"
             }
           }
-        }
-      }
-    },
-    "nodemailer-smtp-transport": {
-      "version": "0.1.13",
-      "from": "nodemailer-smtp-transport@",
-      "resolved": "https://registry.npmjs.org/nodemailer-smtp-transport/-/nodemailer-smtp-transport-0.1.13.tgz",
-      "dependencies": {
-        "nodemailer-wellknown": {
-          "version": "0.1.5",
-          "from": "nodemailer-wellknown@^0.1.1",
-          "resolved": "https://registry.npmjs.org/nodemailer-wellknown/-/nodemailer-wellknown-0.1.5.tgz"
-        },
-        "smtp-connection": {
-          "version": "1.1.0",
-          "from": "smtp-connection@^1.0.0",
-          "resolved": "https://registry.npmjs.org/smtp-connection/-/smtp-connection-1.1.0.tgz"
         }
       }
     },

--- a/package.json
+++ b/package.json
@@ -28,7 +28,6 @@
     "mkdirp": "^0.5.0",
     "node-logentries": "^0.1.4",
     "nodemailer": "^1.3.0",
-    "nodemailer-smtp-transport": "^0.1.13",
     "parse-env": "0.2.2",
     "request": "2.33.0",
     "rest-sugar": "0.6.3",


### PR DESCRIPTION
The nodemailer-smtp-transport module is built in to the nodemailer module and is used by default when a javascript object is passed into the nodemailer constructor, so there is no need of this module.