### PR TITLE
Add missing versions

### DIFF
--- a/lib/sort_versions.js
+++ b/lib/sort_versions.js
@@ -1,14 +1,89 @@
 'use strict';
 
-var Semvish = require('semvish');
+var dPattern = /^\d+$/;
+var pPattern = /[-.]|\d+|[^-.\d].*/g;
+var tPattern = /[a-z]|-\d+$/;
+var nPattern = /\d+|[^\d]+/g;
 
-
-module.exports = function(arr) {
+module.exports = function (arr) {
     if(!arr) {
         return;
     }
 
-    return arr.filter(function(v) {
-      return Semvish.valid(v, false);
-    }).sort(Semvish.rcompare);
+    return arr.sort(versionCompare);
 };
+
+function versionCompare (versionA, versionB) {
+	var ax = versionA.match(pPattern);
+	var bx = versionB.match(pPattern);
+
+	while (ax && bx && ax.length && bx.length) {
+		var a = ax.shift();
+		var b = bx.shift();
+
+		if (a === b) {
+			// continue
+		} else if ((a === '-' || a === '.') && dPattern.test(a)) {
+			return 1;
+		} else if ((b === '-' || b === '.') && dPattern.test(b)) {
+			return -1;
+		} else if (dPattern.test(a) && dPattern.test(b)) {
+			return b - a;
+		} else {
+			return compareStrings(a, b);
+		}
+	}
+
+	// 1.1.0-alpha > 1.0
+	if (ax.length > 2) {
+		return -1;
+	} else if (bx.length  > 2) {
+		return 1;
+	}
+
+	return compareStrings(versionA, versionB);
+}
+
+function compareStrings (versionA, versionB) {
+	versionA = versionA.toLowerCase();
+	versionB = versionB.toLowerCase();
+
+	// 1.0.0 > 1.0.0-alpha
+	if (tPattern.test(versionA) && !tPattern.test(versionB)) {
+		return 1;
+	} else if (tPattern.test(versionB) && !tPattern.test(versionA)) {
+		return -1;
+	}
+
+	// 1.0.0-alpha.10 > 1.0.0-alpha.9
+	var ax = versionA.match(nPattern);
+	var bx = versionB.match(nPattern);
+
+	while (ax && bx && ax.length && bx.length) {
+		var a = ax.shift();
+		var b = bx.shift();
+
+		if (dPattern.test(a)) {
+			a = Number(a);
+		}
+
+		if (dPattern.test(b)) {
+			b = Number(b);
+		}
+
+		if (a > b) {
+			return -1;
+		} else if (a < b) {
+			return 1;
+		}
+	}
+
+	// 1.0.0 > 1.0
+	if (ax.length) {
+		return -1;
+	} else if (bx.length) {
+		return 1;
+	}
+
+	return 0;
+}

--- a/package.json
+++ b/package.json
@@ -34,8 +34,7 @@
     "parse-env": "0.2.2",
     "recursive-readdir": "^1.2.1",
     "request": "2.33.0",
-    "rest-sugar": "0.6.3",
-    "semvish": "^1.1.0"
+    "rest-sugar": "0.6.3"
   },
   "repository": {
     "type": "git",

--- a/tasks/google.js
+++ b/tasks/google.js
@@ -60,8 +60,12 @@ function scrape(data) {
           , homepage = $($libElements[1]).find('a').attr('href')
           , mainfile = $libElements.find('code').text().split('"').slice(-2, -1)[0].split('/').slice(-1)[0]
           , name = $libElements.find('code').text().split('"').slice(-2, -1)[0].split('/')[5]
-          , versions = $versionElements.text().split(",").filter(id).map(trim)
-          , hasMin = $libElements.find('code').text().indexOf('.min.js') !== -1;
+          , hasMin = $libElements.find('code').text().indexOf('.min.js') !== -1
+          , versions = [];
+
+        $versionElements.each(function () {
+          [].push.apply(versions, $(this).text().split(",").filter(id).map(trim));
+        });
 
         ret.push({
           name: name,


### PR DESCRIPTION
1. Fixes google scraping; [versions](https://developers.google.com/speed/libraries/#angular-material) were parsed incorrectly for some projects and some [of them were missing](http://api.jsdelivr.com/v1/google/libraries/angular_material).
2. When we started sorting versions (jsdelivr/api#104) using semvish, versions of some projects disappeared from the API, because semvish couldn't parse them. E.g. see [prototype](http://api.jsdelivr.com/v1/google/libraries/prototype) (affects about 40 libs). I switched to using a more general algorithm.

Should be safe to merge immediately as it's just bug fixes.